### PR TITLE
Fix remove_punct bug

### DIFF
--- a/rag_experiment_accelerator/nlp/preprocess.py
+++ b/rag_experiment_accelerator/nlp/preprocess.py
@@ -41,7 +41,7 @@ class Preprocess:
         Returns:
             str: The text with all punctuation removed.
         """
-        return " ".join(c for c in text if c not in punctuation)
+        return "".join(c for c in text if c not in punctuation)
 
     def remove_Tags(self, text):
         """

--- a/rag_experiment_accelerator/nlp/tests/test_preprocessor.py
+++ b/rag_experiment_accelerator/nlp/tests/test_preprocessor.py
@@ -1,9 +1,5 @@
 from rag_experiment_accelerator.nlp.preprocess import Preprocess
 
-# Bug with vscode and pytest
-import sys
-
-sys.path.append("/workspaces/rag-experiment-accelerator/nlp")
 
 
 def test_sentence_tokenize():
@@ -32,3 +28,10 @@ def test_lemmatize():
     text = "kites babies dogs flying smiling driving died tried feet"
     expected = "kite baby dog fly smile drive die try foot"
     assert preprocessor.lemmatize(text) == expected
+
+
+def test_remove_punct():
+    preprocessor = Preprocess()
+    text = """this!" is*+,-. /a#$ sentence%& with'() a:;<= lot>?@[ of\\]^_ punctuation`{|}~"""
+    expected = "this is a sentence with a lot of punctuation"
+    assert preprocessor.remove_punct(text) == expected


### PR DESCRIPTION
This function was removing the punction but was also adding a space after each character. This fixes that.

old result: `t h i s   i s   a   s e n t e n c e   w i t h   a   l o t   o f   p u n c t u a t i o n`
new result: `this is a sentence with a lot of punctuation`