### PR TITLE
Adding Small Fix For Generation of Embeddings

### DIFF
--- a/rag_experiment_accelerator/embedding/gen_embeddings.py
+++ b/rag_experiment_accelerator/embedding/gen_embeddings.py
@@ -23,15 +23,24 @@ def generate_embedding(size: int, chunk: str, model_name: str) -> list[float]:
         list[float]: A list of floats representing the embedding for the given text chunk.
     """
     if size == 1536:
-        params = {
-            "input": [chunk],
-        }
-        if openai.api_type == "azure":
-            params["engine"] = model_name
+        # Check if the input is too large
+        if len(chunk) > 8191:
+            # If so, break it up into smaller chunks
+            chunks = [chunk[i:i + 8191] for i in range(0, len(chunk), 8191)]
         else:
-            params["model"] = model_name
+            # Otherwise, proceed as normal
+            chunks = [chunk]
 
-        embedding = openai.Embedding.create(**params)["data"][0]["embedding"]
+        for chunk in chunks:
+            params = {
+                "input": [chunk],
+            }
+            if openai.api_type == "azure":
+                params["engine"] = model_name
+            else:
+                params["model"] = model_name
+
+            embedding = openai.Embedding.create(**params)["data"][0]["embedding"]
         return [embedding]
 
     if size in size_model_mapping:


### PR DESCRIPTION
**Context**

if we input 1536 in **embedding_dimension field in search_config.json**, which is the dimension length required for the vectors belonging to embeddings model  (text-embeddings-ada-002) for experimentation within prompt flow for example, we run into the following error.

`{"error"=>{"message"=>"This model's maximum context length is 8191 tokens, however you requested 8589 tokens (8589 in your prompt; 0 for the completion). Please reduce your prompt; or completion length.", "type"=>"invalid_request_error", "param"=>nil, "code"=>nil}}`

**Solution/Suggestion Fix**
The PR provides a suggestion fix to resolve the issue. The fix is to further break into smaller chunks to be processed by the embedding model.