### PR TITLE
Catch and handle openai invalid request in 03_querying.py

### DIFF
--- a/rag_experiment_accelerator/embedding/gen_embeddings.py
+++ b/rag_experiment_accelerator/embedding/gen_embeddings.py
@@ -37,5 +37,7 @@ def generate_embedding(size: int, chunk: str, model_name: str) -> list[float]:
     if size in size_model_mapping:
         model = SentenceTransformer(size_model_mapping[size])
         return model.encode([str(chunk)]).tolist()
-
-    # todo: log error and/or handle the default setup
+    else:
+        raise ValueError(
+            f"Invalid embedding size {size}. Size must be one of 1536, {list(size_model_mapping.keys())}."
+        )


### PR DESCRIPTION
closes #164 
This catches `openai.error.InvalidRequestError` and will skip the question when this is raised.

This will skip the question the token count is above the token limit for openai models.