### PR TITLE
Use strings for model mapping keys

### DIFF
--- a/rag_experiment_accelerator/embedding/gen_embeddings.py
+++ b/rag_experiment_accelerator/embedding/gen_embeddings.py
@@ -2,9 +2,9 @@ import openai
 from sentence_transformers import SentenceTransformer
 
 size_model_mapping = {
-    384: "all-MiniLM-L6-v2",
-    768: "all-mpnet-base-v2",
-    1024: "bert-large-nli-mean-tokens",
+    '384': "all-MiniLM-L6-v2",
+    '768': "all-mpnet-base-v2",
+    '1024': "bert-large-nli-mean-tokens",
 }
 
 
@@ -34,8 +34,8 @@ def generate_embedding(size: int, chunk: str, model_name: str) -> list[float]:
         embedding = openai.Embedding.create(**params)["data"][0]["embedding"]
         return [embedding]
 
-    if size in size_model_mapping:
-        model = SentenceTransformer(size_model_mapping[size])
+    if str(size) in size_model_mapping:
+        model = SentenceTransformer(size_model_mapping[str(size)])
         return model.encode([str(chunk)]).tolist()
 
     # todo: log error and/or handle the default setup


### PR DESCRIPTION
@ritesh-modi I wasn't able to reproduce the error that you were getting when the keys were type `int`. I updated the keys to be strings and cast the size to a str when getting the mapping. Please let me know if this change resolves your issue.