### PR TITLE
fix config_dir bug

### DIFF
--- a/rag_experiment_accelerator/config/config.py
+++ b/rag_experiment_accelerator/config/config.py
@@ -302,7 +302,7 @@ class Config:
 
     _instance = None 
 
-    def __new__(cls, config_filename: str = "config.json"):
+    def __new__(cls, config_dir: str = os.getcwd()):
         """
         Creates a new instance of Config only if it doesn't already exist.
 
@@ -315,10 +315,10 @@ class Config:
 
         if cls._instance is None:
             cls._instance = super(Config, cls).__new__(cls)
-            cls._instance._initialize(config_filename)
+            cls._instance._initialize(config_dir)
         return cls._instance
     
-    def _initialize(self, config_dir: str = os.getcwd()) -> None:
+    def _initialize(self, config_dir: str) -> None:
         with open(f"{config_dir}/config.json", "r") as json_file:
             data = json.load(json_file)
 


### PR DESCRIPTION
Not supplying an argument to the `Config()`  causes it to try and read data from `config.json/config.json`. This fixes that. The config directory can be supplied, otherwise it defaults to the cwd.