### PR TITLE
Update acs_ingest.py

### DIFF
--- a/rag_experiment_accelerator/ingest_data/acs_ingest.py
+++ b/rag_experiment_accelerator/ingest_data/acs_ingest.py
@@ -128,8 +128,8 @@ def upload_data(
 
         documents.append(input_data)
 
-        search_client.upload_documents(documents)
-        logger.info(f"Uploaded {len(documents)} documents")
+        search_client.upload_documents([input_data])
+    logger.info(f"Uploaded {len(documents)} documents")
     logger.info("all documents have been uploaded to the search index")
 
 


### PR DESCRIPTION
Small bug fix - The ACS ingest script was uploading more documents each loop.

On the first chunk, it uploaded the first chunk. On the second chunk, it uploaded the first, and the second. On the third, it uploaded the first, second, and third, and so on. This meant the code for uploading to the ACS index was taking exponentially longer than it was meant to.