### PR TITLE
Cancel in progress workflows on PRs when new push

### DIFF
--- a/rag_experiment_accelerator/evaluation/tests/test_eval.py
+++ b/rag_experiment_accelerator/evaluation/tests/test_eval.py
@@ -28,7 +28,7 @@ def test_bleu():
     assert round(score) == 50
 
 
-@patch("rag_experiment_accelerator.evaluation.eval.generate_response")
+@patch("rag_experiment_accelerator.llm.response_generator.ResponseGenerator.generate_response")
 def test_llm_answer_relevance(mock_generate_response):
     mock_generate_response.return_value = "What is the name of the largest bone in the human body?"
 
@@ -40,7 +40,7 @@ def test_llm_answer_relevance(mock_generate_response):
     assert round(score) == 100
 
 
-@patch("rag_experiment_accelerator.evaluation.eval.generate_response")
+@patch("rag_experiment_accelerator.llm.response_generator.ResponseGenerator.generate_response")
 def test_llm_context_precision(mock_generate_response):
     mock_generate_response.return_value = "Yes"
     question = "What is the name of the largest bone in the human body?"

--- a/rag_experiment_accelerator/ingest_data/acs_ingest.py
+++ b/rag_experiment_accelerator/ingest_data/acs_ingest.py
@@ -123,8 +123,8 @@ def upload_data(
 
         documents.append(input_data)
 
-        search_client.upload_documents(documents)
-        logger.info(f"Uploaded {len(documents)} documents")
+        search_client.upload_documents([input_data])
+    logger.info(f"Uploaded {len(documents)} documents")
     logger.info("all documents have been uploaded to the search index")
 
 
@@ -175,13 +175,12 @@ def generate_qna(docs, azure_oai_deployment_name):
     return new_df
 
 
-def we_need_multiple_questions(question):
+def we_need_multiple_questions(question, azure_oai_deployment_name):
     """
     Generates a response to a given question using a language model with multiple prompts.
 
     Args:
         question (str): The question to generate a response for.
-        model_name (str): The name of the language model to use.
         azure_oai_deployment_name (str): The name of the Azure Opan AI deployment 
 
     Returns:


### PR DESCRIPTION
closes #233 

This will cancel in process workflows when there is a new push to a PR. Workflows will not be canceled when merged to
`development` or `main`
 