### PR TITLE
Allow PRs from forked repos to run build validation job

### DIFF
--- a/.github/workflows/build_validation_workflow.yml
+++ b/.github/workflows/build_validation_workflow.yml
@@ -8,7 +8,9 @@ on:
       - main
       - development
   push:
-
+    branches:
+      - main
+      - development
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/development' && github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
The build validation job was stuck in `expected` state for PRs that came from forks. This should fix that.

We should also think about not allowing forked repos to change the github action files. Someone could potentially do bad things 