### PR TITLE
Add SSH mount in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,5 +20,8 @@
 				"ms-azuretools.azure-dev"
 			]
 		}
-	}
+	},
+	"mounts": [
+		"source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+	]
 }


### PR DESCRIPTION
mounting `.ssh` folder in home directory will allow interacting with git using ssh key on host machine.