### PR TITLE
Fix pytest issue in devcontainer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,7 +6,7 @@ pip install -r requirements.txt
 
 pip install -r dev-requirements.txt
 
-# install the rag-accelerator package in editable mode (requiered for pre-commit to work properly with pytest)
+# install the rag-accelerator packages in editable mode (required for pre-commit to work properly with pytest)
 pip install -e .
 
 pre-commit install

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,4 +6,7 @@ pip install -r requirements.txt
 
 pip install -r dev-requirements.txt
 
+# install the rag-accelerator package in editable mode (requiered for pre-commit to work properly with pytest)
+pip install -e .
+
 pre-commit install

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ data/*
 .azure
 
 .vscode
+
+test_artifacts_dir/*


### PR DESCRIPTION
This pull request includes a change to the `.devcontainer/post-create.sh` file. The change adds a command to install the rag-accelerator package in editable mode. This is required for the pre-commit to work properly with pytest.