### PR TITLE
Fix initialisation of index config

### DIFF
--- a/rag_experiment_accelerator/config/config.py
+++ b/rag_experiment_accelerator/config/config.py
@@ -155,6 +155,9 @@ class Config:
                                 embedding_model=embedding_model,
                                 ef_construction=ef_construction,
                                 ef_search=ef_search,
+                                sampling_percentage=self.SAMPLE_PERCENTAGE
+                                if self.SAMPLE_DATA
+                                else 0,
                             )
 
     def _initialize_paths(


### PR DESCRIPTION
Missed change from https://github.com/microsoft/rag-experiment-accelerator/pull/343 - fixing initialisation of IndexConfig to make sure to propagate sampling settings. This was in my branch locally but I forgot to push the recent changes before merging. 

Been tested while ran locally.