### PR TITLE
Fix Document Intelligence loader

### DIFF
--- a/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
@@ -7,15 +7,15 @@ from rag_experiment_accelerator.config.environment import Environment
 logger = get_logger(__name__)
 
 
-def get_supported_formats() -> list[str]:
+def is_supported_by_document_intelligence(format: str) -> bool:
     """
-    Get supported formats for the Azure Document Intelligence loader.
+    Returns whether a format is supported by Azure Document Intelligence or not.
 
     Returns:
-        list[str]: List of formats.
+        bool: True if the format is supported, False otherwise.
     """
 
-    return ["pdf", "html", "markdown", "json", "text", "docx"]
+    return format.lower() in ["pdf", "html", "markdown", "json", "text", "docx"]
 
 
 def load_with_azure_document_intelligence(

--- a/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
@@ -1,3 +1,4 @@
+import uuid
 from langchain_community.document_loaders import AzureAIDocumentIntelligenceLoader
 from langchain_core.documents import Document
 
@@ -15,7 +16,19 @@ def is_supported_by_document_intelligence(format: str) -> bool:
         bool: True if the format is supported, False otherwise.
     """
 
-    return format.lower() in ["pdf", "html", "markdown", "json", "text", "docx"]
+    return format.lower() in [
+        "pdf",
+        "jpeg",
+        "jpg",
+        "png",
+        "bmp",
+        "heif",
+        "tiff",
+        "docx",
+        "xlsx",
+        "pptx",
+        "html",
+    ]
 
 
 def load_with_azure_document_intelligence(
@@ -48,4 +61,4 @@ def load_with_azure_document_intelligence(
         except Exception as e:
             logger.warning(f"Failed to load {file_path}: {e}")
 
-    return documents
+    return [{str(uuid.uuid4()): doc.page_content} for doc in documents]

--- a/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
@@ -7,6 +7,17 @@ from rag_experiment_accelerator.config.environment import Environment
 logger = get_logger(__name__)
 
 
+def get_supported_formats() -> list[str]:
+    """
+    Get supported formats for the Azure Document Intelligence loader.
+
+    Returns:
+        list[str]: List of formats.
+    """
+
+    return ["pdf", "html", "markdown", "json", "text", "docx"]
+
+
 def load_with_azure_document_intelligence(
     environment: Environment,
     file_paths: list[str],

--- a/rag_experiment_accelerator/doc_loader/documentLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentLoader.py
@@ -9,6 +9,7 @@ from rag_experiment_accelerator.doc_loader.markdownLoader import (
 from rag_experiment_accelerator.doc_loader.pdfLoader import load_pdf_files
 from rag_experiment_accelerator.doc_loader.textLoader import load_text_files
 from rag_experiment_accelerator.doc_loader.documentIntelligenceLoader import (
+    get_supported_formats,
     load_with_azure_document_intelligence,
 )
 from rag_experiment_accelerator.utils.logging import get_logger
@@ -39,7 +40,10 @@ def determine_processor(chunking_strategy: ChunkingStrategy, format: str) -> cal
     """
     Determine and return document processor based on chunking strategy and format.
     """
-    if chunking_strategy == ChunkingStrategy.AZURE_DOCUMENT_INTELLIGENCE:
+    if (
+        chunking_strategy == ChunkingStrategy.AZURE_DOCUMENT_INTELLIGENCE
+        and format in get_supported_formats()
+    ):
         return load_with_azure_document_intelligence
     else:
         return _FORMAT_PROCESSORS[format]

--- a/rag_experiment_accelerator/doc_loader/documentLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentLoader.py
@@ -9,7 +9,7 @@ from rag_experiment_accelerator.doc_loader.markdownLoader import (
 from rag_experiment_accelerator.doc_loader.pdfLoader import load_pdf_files
 from rag_experiment_accelerator.doc_loader.textLoader import load_text_files
 from rag_experiment_accelerator.doc_loader.documentIntelligenceLoader import (
-    get_supported_formats,
+    is_supported_by_document_intelligence,
     load_with_azure_document_intelligence,
 )
 from rag_experiment_accelerator.utils.logging import get_logger
@@ -42,7 +42,7 @@ def determine_processor(chunking_strategy: ChunkingStrategy, format: str) -> cal
     """
     if (
         chunking_strategy == ChunkingStrategy.AZURE_DOCUMENT_INTELLIGENCE
-        and format in get_supported_formats()
+        and is_supported_by_document_intelligence(format)
     ):
         return load_with_azure_document_intelligence
     else:


### PR DESCRIPTION
# Resolves #430 

* Removed the usage of Document Intelligence for unsupported file formats.
* Aligned the return type of the `load_with_azure_document_intelligence` method with the rest of the loader methods - resolving the exception that is currently being thrown