### PR TITLE
447: Add model configuration for Azure Doc Intelligence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Alternatively, you can run the above steps (apart from `02_qa_generation.py`) us
     "openai_temperature": "determines the OpenAI temperature. Valid value ranges from 0 to 1.",
     "search_relevancy_threshold": "the similarity threshold to determine if a doc is relevant. Valid ranges are from 0.0 to 1.0",
     "chunking_strategy": "determines the chunking strategy. Valid values are 'azure-document-intelligence' or 'basic'",
+    "azure_document_intelligence_model": "represents the Azure Document Intelligence Model. Used when chunking strategy is 'azure-document-intelligence'."
 }
 ```
 

--- a/config.json
+++ b/config.json
@@ -48,7 +48,7 @@
     "search_relevancy_threshold": 0.8,
     "data_formats": "all",
     "eval_data_jsonl_file_path": "./artifacts/eval_data.jsonl",
-    "chunking_strategy": "azure-document-intelligence",
+    "chunking_strategy": "basic",
     "azure_document_intelligence_model": "prebuilt-read",
     "generate_title": false,
     "generate_summary": false,

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "name_prefix": "guy6",
+    "name_prefix": "surface",
     "chunking": {
         "chunk_size": [1000],
         "overlap_size": [200]
@@ -48,7 +48,8 @@
     "search_relevancy_threshold": 0.8,
     "data_formats": "all",
     "eval_data_jsonl_file_path": "./artifacts/eval_data.jsonl",
-    "chunking_strategy": "basic",
+    "chunking_strategy": "azure-document-intelligence",
+    "azure_document_intelligence_model": "prebuilt-read",
     "generate_title": false,
     "generate_summary": false,
     "override_content_with_summary": false

--- a/rag_experiment_accelerator/config/config.py
+++ b/rag_experiment_accelerator/config/config.py
@@ -43,6 +43,8 @@ class Config:
         RERANK_TYPE (str): The type of reranking to use.
         LLM_RERANK_THRESHOLD (float): The threshold for reranking using LLM.
         CROSSENCODER_AT_K (int): The number of documents to rerank using the crossencoder.
+        CHUNKING_STRATEGY (ChunkingStrategy): The strategy to use for chunking documents.
+        AZURE_DOCUMENT_INTELLIGENCE_MODEL (str): The model to use for Azure Document Intelligence extraction.
         TEMPERATURE (float): The temperature to use for OpenAI's GPT-3 model.
         RERANK (bool): Whether or not to perform reranking.
         SEARCH_RELEVANCY_THRESHOLD (float): The threshold for search result relevancy.

--- a/rag_experiment_accelerator/config/config.py
+++ b/rag_experiment_accelerator/config/config.py
@@ -99,6 +99,8 @@ class Config:
             if "chunking_strategy" in config_json
             else ChunkingStrategy.BASIC
         )
+        self.AZURE_DOCUMENT_INTELLIGENCE_MODEL = config_json.get(
+            "azure_document_intelligence_model", "prebuilt-read")
         self.LANGUAGE = config_json.get("language", {})
 
         self.embedding_models: list[EmbeddingModel] = []
@@ -242,7 +244,8 @@ class Config:
         except OSError as e:
             if "Read-only file system" in e.strerror:
                 pass
-            logger.warn(f"Failed to create directory {directory}: {e.strerror}")
+            logger.warn(
+                f"Failed to create directory {directory}: {e.strerror}")
 
     def _sampled_cluster_predictions_path(self):
         return os.path.join(

--- a/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
@@ -62,7 +62,7 @@ def load_with_azure_document_intelligence(
                 ).load()[0].page_content,
                 "metadata": {
                     "source": file_path,
-                    "page": 0
+                    "page": 0   # Azure Document Intelligence always returns a single page so we set it to 0
                 }})
         except Exception as e:
             logger.warning(f"Failed to load {file_path}: {e}")

--- a/rag_experiment_accelerator/doc_loader/documentLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentLoader.py
@@ -56,6 +56,7 @@ def load_documents(
     file_paths: list[str],
     chunk_size: int,
     overlap_size: int,
+    azure_document_intelligence_model: str = None,
 ):
     """
     Load documents from a folder and process them into chunks.
@@ -67,6 +68,7 @@ def load_documents(
         folder_path (str): Path to the folder containing the documents.
         chunk_size (int): Size of each chunk.
         overlap_size (int): Size of overlap between adjacent chunks.
+        azure_document_intelligence_model (str): The model to use for Azure Document Intelligence.
 
     Returns:
         list: A list of dictionaries containing the processed chunks.
@@ -78,7 +80,8 @@ def load_documents(
     if allowed_formats == "all":
         allowed_formats = _FORMAT_VERSIONS.keys()
 
-    logger.debug(f"Loading documents with allowed formats {', '.join(allowed_formats)}")
+    logger.debug(
+        f"Loading documents with allowed formats {', '.join(allowed_formats)}")
 
     documents = {}
 
@@ -100,6 +103,7 @@ def load_documents(
             file_paths=matching_files,
             chunk_size=chunk_size,
             overlap_size=overlap_size,
+            azure_document_intelligence_model=azure_document_intelligence_model,
         )
 
     all_documents = []

--- a/rag_experiment_accelerator/doc_loader/docxLoader.py
+++ b/rag_experiment_accelerator/doc_loader/docxLoader.py
@@ -14,6 +14,7 @@ def load_docx_files(
     file_paths: list[str],
     chunk_size: str,
     overlap_size: str,
+    **kwargs: dict,
 ):
     """
     Load and process docx files from a given folder path.
@@ -23,6 +24,8 @@ def load_docx_files(
         file_paths (list[str]): Sequence of paths to load.
         chunk_size (int): The size of each text chunk in characters.
         overlap_size (int): The size of the overlap between text chunks in characters.
+        **kwargs (dict): Unused.
+        
 
     Returns:
         list[Document]: A list of processed and split document chunks.

--- a/rag_experiment_accelerator/doc_loader/docxLoader.py
+++ b/rag_experiment_accelerator/doc_loader/docxLoader.py
@@ -25,7 +25,7 @@ def load_docx_files(
         chunk_size (int): The size of each text chunk in characters.
         overlap_size (int): The size of the overlap between text chunks in characters.
         **kwargs (dict): Unused.
-        
+
 
     Returns:
         list[Document]: A list of processed and split document chunks.

--- a/rag_experiment_accelerator/doc_loader/htmlLoader.py
+++ b/rag_experiment_accelerator/doc_loader/htmlLoader.py
@@ -14,6 +14,7 @@ def load_html_files(
     file_paths: list[str],
     chunk_size: str,
     overlap_size: str,
+    **kwargs: dict,
 ):
     """
     Load and process HTML files from a given folder path.
@@ -24,6 +25,7 @@ def load_html_files(
         chunk_size (str): The size of the chunks to split the documents into.
         overlap_size (str): The size of the overlapping parts between chunks.
         glob_patterns (list[str]): List of file extensions to consider (e.g., ["html", "htm", ...]).
+        **kwargs (dict): Unused.
 
     Returns:
         list[Document]: A list of processed and split document chunks.

--- a/rag_experiment_accelerator/doc_loader/jsonLoader.py
+++ b/rag_experiment_accelerator/doc_loader/jsonLoader.py
@@ -15,6 +15,7 @@ def load_json_files(
     file_paths: list[str],
     chunk_size: str,
     overlap_size: str,
+    **kwargs: dict,
 ):
     """
     Load and process Json files from a given folder path.
@@ -24,6 +25,7 @@ def load_json_files(
         file_paths (list[str]): Sequence of paths to load.
         chunk_size (int): The size of each text chunk in characters.
         overlap_size (int): The size of the overlap between text chunks in characters.
+        **kwargs (dict): Unused.
 
     Returns:
         list[Document]: A list of processed and split document chunks.

--- a/rag_experiment_accelerator/doc_loader/markdownLoader.py
+++ b/rag_experiment_accelerator/doc_loader/markdownLoader.py
@@ -14,6 +14,7 @@ def load_markdown_files(
     file_paths: list[str],
     chunk_size: str,
     overlap_size: str,
+    **kwargs: dict,
 ):
     """
     Load and process Markdown files from a given folder path.
@@ -23,6 +24,7 @@ def load_markdown_files(
         file_paths (list[str]): Sequence of paths to load.
         chunk_size (str): The size of the chunks to split the documents into.
         overlap_size (str): The size of the overlapping parts between chunks.
+        **kwargs (dict): Unused.
 
     Returns:
         list[Document]: A list of processed and split document chunks.

--- a/rag_experiment_accelerator/doc_loader/pdfLoader.py
+++ b/rag_experiment_accelerator/doc_loader/pdfLoader.py
@@ -42,6 +42,7 @@ def load_pdf_files(
     file_paths: list[str],
     chunk_size: int,
     overlap_size: int,
+    **kwargs: dict,
 ):
     """
     Load PDF files from a folder and split them into chunks of text.
@@ -51,6 +52,7 @@ def load_pdf_files(
         file_paths (list[str]): Sequence of paths to load.
         chunk_size (int): The size of each text chunk in characters.
         overlap_size (int): The size of the overlap between text chunks in characters.
+        **kwargs (dict): Unused.
 
     Returns:
         list[Document]: A list of Document objects, each representing a chunk of text from a PDF file.

--- a/rag_experiment_accelerator/doc_loader/textLoader.py
+++ b/rag_experiment_accelerator/doc_loader/textLoader.py
@@ -14,6 +14,7 @@ def load_text_files(
     file_paths: list[str],
     chunk_size: str,
     overlap_size: str,
+    **kwargs: dict,
 ):
     """
     Load and process text files from a given folder path.
@@ -24,6 +25,7 @@ def load_text_files(
         file_paths (list[str]): Sequence of paths to load.
         chunk_size (int): The size of each text chunk in characters.
         overlap_size (int): The size of the overlap between text chunks in characters.
+        **kwargs (dict): Unused.
 
     Returns:
         list[Document]: A list of processed and split document chunks.

--- a/rag_experiment_accelerator/run/index.py
+++ b/rag_experiment_accelerator/run/index.py
@@ -61,6 +61,7 @@ def run(
         file_paths,
         index_config.chunk_size,
         index_config.overlap,
+        config.AZURE_DOCUMENT_INTELLIGENCE_MODEL,
     )
 
     if config.SAMPLE_DATA:

--- a/rag_experiment_accelerator/run/tests/test_index.py
+++ b/rag_experiment_accelerator/run/tests/test_index.py
@@ -56,6 +56,7 @@ def test_run(
     mock_config.GENERATE_TITLE = False
     mock_config.GENERATE_SUMMARY = False
     mock_config.OVERRIDE_CONTENT_WITH_SUMMARY = False
+    mock_config.AZURE_DOCUMENT_INTELLIGENCE_MODEL = "prebuilt-read"
 
     mock_environment.azure_search_service_endpoint = "service_endpoint"
     mock_environment.azure_search_admin_key = "admin_key"


### PR DESCRIPTION
Fixes #447 

This change now:
1. Fixes the current failure of accelerator when `chunking_strategy` is azure document intelligence
2. Adds the ability for developers to pass the model name to use azure document intelligence.