### PR TITLE
Updating docs to show how to deploy from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you dont want to use `azd` you can use the normal `az` cli too.
 
 ```bash
 az login
-az deployment group create --subscription <subscription-id> --resource-group <resource-group>  --template-file infra/main.bicep
+az deployment sub create --subscription <subscription-id> --location <location>  --template-file infra/main.bicep
 ```
 
 ## How to use


### PR DESCRIPTION
Fixes #486 Updated the docs about deploying from the command line. Bicep uses the subscription scope and the help was showing using a resource group scope.

Test by deploying to a subscription 
![image](https://github.com/microsoft/rag-experiment-accelerator/assets/6254153/e90d4afd-a55b-4ac4-9352-043dd90f25f8)
