### PR TITLE
`index_name_prefix` default value

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,5 +1,5 @@
 {
-    "index_name_prefix": "",
+    "index_name_prefix": "idx",
     "experiment_name": "",
     "job_name": "",
     "job_description": "",


### PR DESCRIPTION
The new `index_name_prefix` should have a default value, otherwise on a fresh clone, it breaks and although the error message is correct, you have to go and understand the code to add this value.

Happy to change it from `idx` if you prefer.

relates to #507 