### PR TITLE
Table chunking with AI Document Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ The **RAG Experiment Accelerator** is config driven and offers a rich set of fea
 
 1. **Rich Search Index**: It creates multiple search indexes based on hyperparameter configurations available in the config file.
 
-1. **Multiple Document Chunking Strategies**: The tool supports multiple chunking strategies, including using Azure Document Intelligence and basic chunking using LangChain. This gives you the flexibility to experiment with different chunking strategies and evaluate their effectiveness.
+1. **Multiple Document Loaders**: The tool supports multiple document loaders, including loading via Azure Document Intelligence and basic LangChain loaders. This gives you the flexibility to experiment with different extraction methods and evaluate their effectiveness.
 
-1. **Custom Document Intelligence Loader** : When selecting the 'prebuilt-layout' API model for Document Intelligence, the tool utilizes a custom Document Intelligence loader to load the data. This custom loader supports formatting of tables into key-value pairs (to enhance readability for the LLM), excludes irrelevant parts of the file for the LLM (such as page numbers and footers), removes recurring patterns in the file using regex, and more. The custom loader resorts to the simpler 'prebuilt-layout' API model as a fallback when the 'prebuilt-layout' fails. Any other API model will utilize LangChain's implementation, which returns the raw response from Document Intelligence's API.
+1. **Custom Document Intelligence Loader** : When selecting the 'prebuilt-layout' API model for Document Intelligence, the tool utilizes a custom Document Intelligence loader to load the data. This custom loader supports formatting of tables with column headers into key-value pairs (to enhance readability for the LLM), excludes irrelevant parts of the file for the LLM (such as page numbers and footers), removes recurring patterns in the file using regex, and more. Since each table row is transformed into a text line, to avoid breaking a row in the middle, chunking is done recursively by paragraph and line.
+The custom loader resorts to the simpler 'prebuilt-layout' API model as a fallback when the 'prebuilt-layout' fails. Any other API model will utilize LangChain's implementation, which returns the raw response from Document Intelligence's API.
 
 1. **Query Generation**: The tool can generate a variety of diverse and customizable query sets, which can be tailored for specific experimentation needs.
 

--- a/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
@@ -172,11 +172,14 @@ class DocumentIntelligenceLoader(BaseLoader):
                 result.paragraphs, result.tables
             )
 
-            relevant_paragraphs = [
-                paragraph
-                for paragraph in paragraphs
-                if paragraph["role"] not in self.excluded_paragraph_roles
-            ]
+            relevant_paragraphs = []
+            for paragraph in paragraphs:
+                if "role" in paragraph.keys():
+                    if paragraph["role"] not in self.excluded_paragraph_roles:
+                        relevant_paragraphs.append(paragraph)
+                else:
+                    relevant_paragraphs.append(paragraph)
+
             paragraphs_by_role = self._get_paragraphs_by_role(result)
 
             if self.split_documents_by_page:
@@ -228,16 +231,15 @@ class DocumentIntelligenceLoader(BaseLoader):
     def _get_paragraphs_by_role(self, result):
         dict = {}
         for paragraph in result.paragraphs:
-            if (
-                not paragraph["role"]
-                or paragraph["role"] in self.excluded_paragraph_roles
-            ):
-                continue
-            paragraph_item = {
-                "content": paragraph.content,
-                "page": paragraph.bounding_regions[0].get("pageNumber"),
-            }
-            dict[paragraph["role"]] = dict.get(paragraph["role"], []) + [paragraph_item]
+            if "role" in paragraph.keys():
+                if paragraph["role"] not in self.excluded_paragraph_roles:
+                    paragraph_item = {
+                        "content": paragraph.content,
+                        "page": paragraph.bounding_regions[0].get("pageNumber"),
+                    }
+                    dict[paragraph["role"]] = dict.get(paragraph["role"], []) + [
+                        paragraph_item
+                    ]
 
         tables = []
         for table in result.tables:

--- a/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
@@ -5,6 +5,7 @@ import os
 import uuid
 from azure.ai.documentintelligence import DocumentIntelligenceClient
 from langchain_community.document_loaders import AzureAIDocumentIntelligenceLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
 from rag_experiment_accelerator.config.environment import Environment
 from azure.core.credentials import AzureKeyCredential
 from langchain_core.documents import Document
@@ -44,6 +45,8 @@ def is_supported_by_document_intelligence(format: str) -> bool:
 def load_with_azure_document_intelligence(
     environment: Environment,
     file_paths: list[str],
+    chunk_size: int,
+    overlap_size: int,
     azure_document_intelligence_model: str,
     **kwargs: dict,
 ) -> list[Document]:
@@ -53,6 +56,8 @@ def load_with_azure_document_intelligence(
     Args:
         environment (Environment): The environment class
         file_paths (list[str]): Sequence of paths to load.
+        chunk_size (int): The size of each text chunk in characters.
+        overlap_size (int): The size of the overlap between text chunks in characters.
         azure_document_intelligence_model (str): The model to use for Azure Document Intelligence.
         **kwargs (dict): Unused.
 
@@ -80,7 +85,18 @@ def load_with_azure_document_intelligence(
         except Exception as e:
             logger.warning(f"Failed to load {file_path}: {e}")
 
-    return [{str(uuid.uuid4()): doc.__dict__} for doc in documents]
+    logger.debug(f"Loaded {len(documents)} documents using Azure Document Intelligence")
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=overlap_size,
+    )
+
+    logger.debug(
+        f"Splitting extracted documents into chunks of {chunk_size} characters with an overlap of {overlap_size} characters"
+    )
+    docs = text_splitter.split_documents(documents)
+
+    return [{str(uuid.uuid4()): doc.__dict__} for doc in docs]
 
 
 class DocumentIntelligenceLoader(BaseLoader):
@@ -180,20 +196,18 @@ class DocumentIntelligenceLoader(BaseLoader):
                 else:
                     relevant_paragraphs.append(paragraph)
 
-            paragraphs_by_role = self._get_paragraphs_by_role(result)
-
             if self.split_documents_by_page:
                 paragraphs_by_page = self._split_paragraphs_by_page(relevant_paragraphs)
                 for page_number, page_paragraphs in paragraphs_by_page.items():
                     documents.append(
                         self._convert_to_langchain_document(
-                            page_paragraphs, file_path, paragraphs_by_role, page_number
+                            page_paragraphs, file_path, page_number
                         )
                     )
             else:
                 documents.append(
                     self._convert_to_langchain_document(
-                        relevant_paragraphs, file_path, paragraphs_by_role, 1
+                        relevant_paragraphs, file_path, 1
                     )
                 )
 
@@ -228,40 +242,13 @@ class DocumentIntelligenceLoader(BaseLoader):
 
         return content
 
-    def _get_paragraphs_by_role(self, result):
-        dict = {}
-        for paragraph in result.paragraphs:
-            if "role" in paragraph.keys():
-                if paragraph["role"] not in self.excluded_paragraph_roles:
-                    paragraph_item = {
-                        "content": paragraph.content,
-                        "page": paragraph.bounding_regions[0].get("pageNumber"),
-                    }
-                    dict[paragraph["role"]] = dict.get(paragraph["role"], []) + [
-                        paragraph_item
-                    ]
-
-        tables = []
-        for table in result.tables:
-            table_item = {
-                "cells": table.cells,
-                "page": table.bounding_regions[0].get("pageNumber"),
-            }
-            tables.append(table_item)
-        dict["tables"] = tables
-
-        return dict
-
-    def _convert_to_langchain_document(
-        self, paragraphs, file_path, paragraphs_by_role, page_number
-    ):
+    def _convert_to_langchain_document(self, paragraphs, file_path, page_number):
         content = "\n\n".join([paragraph.content for paragraph in paragraphs])
         clean_content = self._clean_content(content)
         return Document(
             page_content=clean_content,
             metadata={
                 "source": file_path,
-                "paragraphs_by_role": paragraphs_by_role,
                 "page": page_number - 1,
             },
         )

--- a/rag_experiment_accelerator/doc_loader/tests/test_document_intelligence_loader.py
+++ b/rag_experiment_accelerator/doc_loader/tests/test_document_intelligence_loader.py
@@ -15,6 +15,9 @@ class SimplePythonObject:
     def get(self, key, default=None):
         return getattr(self, key, default)
 
+    def keys(self):
+        return self.__dict__.keys()
+
 
 def mock_simple_response(file_name):
     with open(


### PR DESCRIPTION
closes #432

This PR adds recursive chunking to docs extracted using AI Document Intelligence:

- Extracted tables are transformed into a text format where each table row corresponds to a text line. To avoid breaking a row in the middle, chunking is done recursively by paragraph and by line.
- This PR also fixes two bugs in `documentIntelligenceLoader.py`: a KeyError when AI Document Intelligence doesn't detect the role for a paragraph, a bug when the doc doesn't contain any tables. Drop unused paragraph_by_role metadata.