### PR TITLE
multiquestions check and generations are turned off by default

### DIFF
--- a/.github/workflows/config.json
+++ b/.github/workflows/config.json
@@ -58,5 +58,6 @@
     "hyde": "generated_hypothetical_answer",
     "query_expansion": true,
     "min_query_expansion_related_question_similarity_score": 90,
-    "azure_document_intelligence_model": "prebuilt-read"
+    "azure_document_intelligence_model": "prebuilt-read",
+    "expand_to_multiple_questions": false
 }

--- a/config.sample.json
+++ b/config.sample.json
@@ -60,5 +60,6 @@
     "hyde": "disabled",
     "query_expansion": false,
     "min_query_expansion_related_question_similarity_score": 90,
-    "azure_document_intelligence_model": "prebuilt-read"
+    "azure_document_intelligence_model": "prebuilt-read",
+    "expand_to_multiple_questions": false
 }

--- a/rag_experiment_accelerator/config/config.py
+++ b/rag_experiment_accelerator/config/config.py
@@ -168,6 +168,9 @@ class Config:
         self.MIN_QUERY_EXPANSION_RELATED_QUESTION_SIMILARITY_SCORE = int(
             config_json.get("min_query_expansion_related_question_similarity_score", 90)
         )
+        self.EXPAND_TO_MULTIPLE_QUESTIONS = config_json.get(
+            "expand_to_multiple_questions", False
+        )
         self.validate_semantic_search_config(
             environment.azure_search_use_semantic_search.lower() == "true"
         )

--- a/rag_experiment_accelerator/run/querying.py
+++ b/rag_experiment_accelerator/run/querying.py
@@ -386,9 +386,11 @@ def query_and_eval_single_line(
     output_prompt = data.get("output_prompt")
     qna_context = data.get("context", "")
 
-    is_multi_question = do_we_need_multiple_questions(
-        user_prompt, response_generator, config
+    is_multi_question = (
+        config.EXPAND_TO_MULTIPLE_QUESTIONS
+        and do_we_need_multiple_questions(user_prompt, response_generator, config)
     )
+
     if is_multi_question:
         try:
             llm_response = we_need_multiple_questions(user_prompt, response_generator)

--- a/rag_experiment_accelerator/run/tests/test_querying.py
+++ b/rag_experiment_accelerator/run/tests/test_querying.py
@@ -34,6 +34,7 @@ class TestQuerying(unittest.TestCase):
         self.mock_config.EMBEDDING_MODEL_NAME = "test-embedding-model"
         self.mock_config.MIN_QUERY_EXPANSION_RELATED_QUESTION_SIMILARITY_SCORE = 90
         self.mock_config.HYDE = "disabled"
+        self.mock_config.EXPAND_TO_MULTIPLE_QUESTIONS = True
         self.mock_environment = MagicMock(spec=Environment)
         self.mock_search_client = MagicMock(spec=SearchClient)
         self.mock_embedding_model = MagicMock(spec=EmbeddingModel)


### PR DESCRIPTION
Added an option to turn off do_multi_question query to save LLM calls. Previously were calling an LLM 2 + number of question times per request: One to determine if we need multiple questions, one to generate extra questions and once per question. Now we can turn it off and call an LLM only once

| Metric                                    | No Multiple Questions | With Multiple Questions |
|-------------------------------------------|-----------------------|-------------------------|
| fuzzy                                     | **81.96**             | 81.69                   |
| bert_all_MiniLM_L6_v2                     | 67.86                 | **68.47**               |
| cosine                                    | 58.26                 | **59.06**               |
| bert_distilbert_base_nli_stsb_mean_tokens | 68.98                 | **69.97**               |
| llm_answer_relevance                      | 58.44                 | **59.54**               |
| llm_context_precision                     | **80.77**             | 80.77                   |
