### PR TITLE
Add chunking strategy to index name

### DIFF
--- a/rag_experiment_accelerator/config/config.py
+++ b/rag_experiment_accelerator/config/config.py
@@ -208,6 +208,7 @@ class Config:
                                 index_name_prefix=self.INDEX_NAME_PREFIX,
                                 preprocess=self.PREPROCESS,
                                 chunk_size=chunk_size,
+                                chunking_strategy=self.CHUNKING_STRATEGY,
                                 overlap=overlap,
                                 embedding_model=embedding_model,
                                 ef_construction=ef_construction,

--- a/rag_experiment_accelerator/config/index_config.py
+++ b/rag_experiment_accelerator/config/index_config.py
@@ -15,6 +15,8 @@ class IndexConfig:
             Whether to preprocess the text before indexing.
         chunk_size (int):
             Chunk size for chunking documents.
+        chunking_strategy (str):
+            Chunking strategy to use for chunking documents.
         overlap (int):
             Overlap size for chunking documents.
         embedding_model (int):
@@ -28,6 +30,7 @@ class IndexConfig:
     index_name_prefix: str
     preprocess: bool
     chunk_size: int
+    chunking_strategy: str
     overlap: int
     embedding_model: EmbeddingModel
     ef_construction: int
@@ -46,6 +49,7 @@ class IndexConfig:
             f"{self.index_name_prefix}"
             f"_p-{int(self.preprocess)}"
             f"_cs-{str(self.chunk_size)}"
+            f"_cs-{str(self.chunking_strategy)}"
             f"_o-{str(self.overlap)}"
             f"_efc-{str(self.ef_construction)}"
             f"_efs-{str(self.ef_search)}"
@@ -69,19 +73,20 @@ class IndexConfig:
         Reverse of index_name().
         """
         values = index_name.split("_")
-        if len(values) != 11:
+        if len(values) != 12:
             raise (f"Invalid index name [{index_name}]")
 
         return IndexConfig(
             index_name_prefix=values[0],
             preprocess=bool(int(cls.__get_index_value(values[1]))),
             chunk_size=int(cls.__get_index_value(values[2])),
-            overlap=int(cls.__get_index_value(values[3])),
-            ef_construction=int(cls.__get_index_value(values[4])),
-            ef_search=int(cls.__get_index_value(values[5])),
-            sampling_percentage=int(cls.__get_index_value(values[6])),
-            generate_title=bool(int(cls.__get_index_value(values[7]))),
-            generate_summary=bool(int(cls.__get_index_value(values[8]))),
-            override_content_with_summary=bool(int(cls.__get_index_value(values[9]))),
-            embedding_model=config._find_embedding_model_by_name(values[10].strip()),
+            chunking_strategy=int(cls.__get_index_value(values[3])),
+            overlap=int(cls.__get_index_value(values[4])),
+            ef_construction=int(cls.__get_index_value(values[5])),
+            ef_search=int(cls.__get_index_value(values[6])),
+            sampling_percentage=int(cls.__get_index_value(values[7])),
+            generate_title=bool(int(cls.__get_index_value(values[8]))),
+            generate_summary=bool(int(cls.__get_index_value(values[9]))),
+            override_content_with_summary=bool(int(cls.__get_index_value(values[10]))),
+            embedding_model=config._find_embedding_model_by_name(values[11].strip()),
         )

--- a/rag_experiment_accelerator/config/index_config.py
+++ b/rag_experiment_accelerator/config/index_config.py
@@ -80,7 +80,7 @@ class IndexConfig:
             index_name_prefix=values[0],
             preprocess=bool(int(cls.__get_index_value(values[1]))),
             chunk_size=int(cls.__get_index_value(values[2])),
-            chunking_strategy=int(cls.__get_index_value(values[3])),
+            chunking_strategy=values[3],
             overlap=int(cls.__get_index_value(values[4])),
             ef_construction=int(cls.__get_index_value(values[5])),
             ef_search=int(cls.__get_index_value(values[6])),

--- a/rag_experiment_accelerator/config/tests/test_index_config.py
+++ b/rag_experiment_accelerator/config/tests/test_index_config.py
@@ -11,6 +11,7 @@ def test_index_config_to_index_name():
         index_name_prefix="prefix",
         preprocess=False,
         chunk_size=1,
+        chunking_strategy="basic",
         overlap=2,
         embedding_model=mock_embedding_model,
         ef_construction=3,
@@ -22,12 +23,12 @@ def test_index_config_to_index_name():
 
     assert (
         index_config.index_name()
-        == "prefix_p-0_cs-1_o-2_efc-3_efs-4_sp-0_t-0_s-0_oc-0_modelname"
+        == "prefix_p-0_cs-1_cs-basic_o-2_efc-3_efs-4_sp-0_t-0_s-0_oc-0_modelname"
     )
 
 
 def test_index_name_to_index_config():
-    index_name = "prefix_p-0_cs-1_o-2_efc-3_efs-4_sp-0_t-0_s-0_oc-0_modelname"
+    index_name = "prefix_p-0_cs-1_cs-basic_o-2_efc-3_efs-4_sp-0_t-0_s-0_oc-0_modelname"
     mock_embedding_model = MagicMock()
     mock_embedding_model.name = "modelname"
     config = MagicMock()

--- a/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentIntelligenceLoader.py
@@ -99,7 +99,15 @@ def load_with_azure_document_intelligence(
 
     docs = text_splitter.split_documents(documents)
 
-    return [{str(uuid.uuid4()): doc.__dict__} for doc in docs]
+    return [
+        {
+            str(uuid.uuid4()): {
+                "content": doc.__dict__["page_content"],
+                "metadata": doc.__dict__["metadata"],
+            }
+        }
+        for doc in docs
+    ]
 
 
 class DocumentIntelligenceLoader(BaseLoader):

--- a/rag_experiment_accelerator/run/tests/test_querying.py
+++ b/rag_experiment_accelerator/run/tests/test_querying.py
@@ -305,7 +305,7 @@ class TestQuerying(unittest.TestCase):
         mock_query_and_eval_acs.return_value = [MagicMock(), MagicMock()]
         mock_search_client = MagicMock(SearchClient)
         index_config = IndexConfig(
-            "prefix", False, 100, 100, self.mock_embedding_model, 400, 400
+            "prefix", False, 100, "basic", 100, self.mock_embedding_model, 400, 400
         )
         mock_config.index_configs.return_value = [index_config]
         # Act


### PR DESCRIPTION
Currently if you run the solution twice once with chunking strategy `basic` and then again with `azure-document-intelligence` the data in the index gets overwritten which is not expected. The fix to this is to add the chunking strategy to the index name.

Fixes include:
- Add chunking strategy to index name