### PR TITLE
lowercase USE_CHECKPOINTS and EXECUTION_ENVIROMENT attributes in config

### DIFF
--- a/01_index.py
+++ b/01_index.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 
     for index_config in config.index_configs():
         init_checkpoint(f"index_{index_config.index_name()}", config)
-        
+
         with mlflow.start_run(
             run_name=f"index_job_{config.job_name}_{formatted_datetime_suffix()}"
         ):

--- a/azureml/pipeline.py
+++ b/azureml/pipeline.py
@@ -13,11 +13,13 @@ from rag_experiment_accelerator.config.paths import (
     formatted_datetime_suffix,
 )  # noqa: E402
 from rag_experiment_accelerator.config.environment import Environment  # noqa: E402
-from rag_experiment_accelerator.config.config import Config, ExecutionEnvironment  # noqa: E402
+from rag_experiment_accelerator.config.config import (
+    Config,
+    ExecutionEnvironment,
+)  # noqa: E402
 from rag_experiment_accelerator.config.index_config import IndexConfig  # noqa: E402
 from rag_experiment_accelerator.utils.auth import get_default_az_cred  # noqa: E402
 from rag_experiment_accelerator.utils.logging import get_logger  # noqa: E402
-from rag_experiment_accelerator.config.paths import mlflow_run_name  # noqa: E402
 
 
 project_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -257,7 +259,7 @@ if __name__ == "__main__":
 
     environment = Environment.from_env_or_keyvault()
     config = Config(environment, args.config_path, args.data_dir)
-    config.EXECUTION_ENVIRONMENT = ExecutionEnvironment.AZURE_ML
+    config.execution_environment = ExecutionEnvironment.AZURE_ML
 
     if config.sampling:
         logger.error(

--- a/rag_experiment_accelerator/checkpoint/checkpoint.py
+++ b/rag_experiment_accelerator/checkpoint/checkpoint.py
@@ -34,10 +34,10 @@ def _get_checkpoint_base_on_config(checkpoint_name, config: Config):
         LocalStorageCheckpoint,
     )
 
-    if not config.USE_CHECKPOINTS:
+    if not config.use_checkpoints:
         return NullCheckpoint()
 
-    if config.EXECUTION_ENVIRONMENT == ExecutionEnvironment.AZURE_ML:
+    if config.execution_environment == ExecutionEnvironment.AZURE_ML:
         # Currently not supported in Azure ML: https://github.com/microsoft/rag-experiment-accelerator/issues/491
         return NullCheckpoint()
 

--- a/rag_experiment_accelerator/checkpoint/tests/test_checkpoint.py
+++ b/rag_experiment_accelerator/checkpoint/tests/test_checkpoint.py
@@ -32,8 +32,8 @@ def test_get_checkpoint_without_init_fails():
 
 def test_get_checkpoint_for_local_executions(mock_checkpoints):
     config = MagicMock()
-    config.EXECUTION_ENVIRONMENT = ExecutionEnvironment.LOCAL
-    config.USE_CHECKPOINTS = True
+    config.execution_environment = ExecutionEnvironment.LOCAL
+    config.use_checkpoints = True
 
     init_checkpoint("test", config)
     checkpoint = get_checkpoint()
@@ -42,8 +42,8 @@ def test_get_checkpoint_for_local_executions(mock_checkpoints):
 
 def test_get_checkpoint_for_azure_ml(mock_checkpoints):
     config = MagicMock()
-    config.EXECUTION_ENVIRONMENT = ExecutionEnvironment.AZURE_ML
-    config.USE_CHECKPOINTS = True
+    config.execution_environment = ExecutionEnvironment.AZURE_ML
+    config.use_checkpoints = True
 
     init_checkpoint("test", config)
     checkpoint = get_checkpoint()
@@ -53,8 +53,8 @@ def test_get_checkpoint_for_azure_ml(mock_checkpoints):
 
 def test_get_checkpoint_when_should_not_use_checkpoints_locally(mock_checkpoints):
     config = MagicMock()
-    config.EXECUTION_ENVIRONMENT = ExecutionEnvironment.LOCAL
-    config.USE_CHECKPOINTS = False
+    config.execution_environment = ExecutionEnvironment.LOCAL
+    config.use_checkpoints = False
 
     init_checkpoint("test", config)
     checkpoint = get_checkpoint()
@@ -63,8 +63,8 @@ def test_get_checkpoint_when_should_not_use_checkpoints_locally(mock_checkpoints
 
 def test_get_checkpoint_when_should_not_use_checkpoints_in_azure_ml(mock_checkpoints):
     config = MagicMock()
-    config.EXECUTION_ENVIRONMENT = ExecutionEnvironment.AZURE_ML
-    config.USE_CHECKPOINTS = False
+    config.execution_environment = ExecutionEnvironment.AZURE_ML
+    config.use_checkpoints = False
 
     init_checkpoint("test", config)
     checkpoint = get_checkpoint()

--- a/rag_experiment_accelerator/checkpoint/tests/test_local_storage_checkpoint.py
+++ b/rag_experiment_accelerator/checkpoint/tests/test_local_storage_checkpoint.py
@@ -31,7 +31,7 @@ class TestLocalStorageCheckpoint(unittest.TestCase):
 
     def test_wrapped_method_is_cached(self):
         config = MagicMock()
-        config.USE_CHECKPOINTS = True
+        config.use_checkpoints = True
         config.artifacts_dir = self.temp_dir
         init_checkpoint("test_save_load", config)
         checkpoint = get_checkpoint()


### PR DESCRIPTION
This PR fixes two config attributes, USE_CHECKPOINTS and EXECUTION_ENVIROMENT, to be lowercase to match the naming conventions and remove unused comment.
