### PR TITLE
feat: add document intelligence to bicep deployment

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -77,6 +77,12 @@ param azureOpenAIModelName string = 'gpt-35-turbo'
 @description('Azure OpenAI GPT Model Version')
 param azureOpenAIModelVersion string = '0613'
 
+@description('Name of Azure AI Document Intelligence Resource')
+param azureAIDocumentIntelligenceResourceName string = 'docintel-${resourceToken}'
+
+@description('Name of Azure AI Document Intelligence SKU')
+param azureAIDocumentIntelligenceSkuName string = 'S0'
+
 @description('Name of Azure Application Insights Resource')
 param applicationInsightsName string = 'appinsights-${resourceToken}'
 
@@ -165,6 +171,20 @@ module openai './shared/cognitiveservices.bicep' = {
   }
 }
 
+module documentIntelligence './shared/cognitiveservices.bicep' = {
+  name: azureAIDocumentIntelligenceResourceName
+  scope: rg
+  params: {
+    name: azureAIDocumentIntelligenceResourceName
+    location: location
+    tags: tags
+    kind: 'FormRecognizer'
+    sku: {
+      name: azureAIDocumentIntelligenceSkuName
+    }
+  }
+}
+
 module storage './shared/storage.bicep' = {
   name: storageAccountName
   scope: rg
@@ -206,6 +226,7 @@ module storekeys './shared/storekeys.bicep' = {
     keyVaultName: keyvault.outputs.name
     azureOpenAIName: openai.outputs.name
     azureAISearchName: search.outputs.name
+    documentIntelligenceName: documentIntelligence.outputs.name
     rgName: rgName
   }
 }
@@ -213,38 +234,37 @@ module storekeys './shared/storekeys.bicep' = {
 // More resources can be added here to deploy with private endpoints.
 // These resources should be added to the azureResources array in the network_resources module.
 // TODO: Add private endpoints to other required resources.
-module network_resources 'network/network_isolation.bicep' =
-  if (vnetAddressSpace != '' && proxySubnetAddressSpace != '' && subnetAddressSpace != '') {
-    name: 'network_isolation_resources'
-    scope: rg
-    params: {
-      vnetName: virtualNetworkName
-      location: location
-      vnetAddressSpace: vnetAddressSpace
-      proxySubnetName: proxySubnetName
-      proxySubnetAddressSpace: proxySubnetAddressSpace
-      azureSubnetName: subnetName
-      azureSubnetAddressSpace: subnetAddressSpace
-      resourcePrefix: environmentName
-      azureResources: [
-        {
-          type: 'blob'
-          name: storage.name
-          resourceId: storage.outputs.id
-        }
-        {
-          type: 'vault'
-          name: keyvault.name
-          resourceId: keyvault.outputs.id
-        }
-        {
-          type: 'amlworkspace'
-          name: machineLearning.name
-          resourceId: machineLearning.outputs.workspaceId
-        }
-      ]
-    }
+module network_resources 'network/network_isolation.bicep' = if (vnetAddressSpace != '' && proxySubnetAddressSpace != '' && subnetAddressSpace != '') {
+  name: 'network_isolation_resources'
+  scope: rg
+  params: {
+    vnetName: virtualNetworkName
+    location: location
+    vnetAddressSpace: vnetAddressSpace
+    proxySubnetName: proxySubnetName
+    proxySubnetAddressSpace: proxySubnetAddressSpace
+    azureSubnetName: subnetName
+    azureSubnetAddressSpace: subnetAddressSpace
+    resourcePrefix: environmentName
+    azureResources: [
+      {
+        type: 'blob'
+        name: storage.name
+        resourceId: storage.outputs.id
+      }
+      {
+        type: 'vault'
+        name: keyvault.name
+        resourceId: keyvault.outputs.id
+      }
+      {
+        type: 'amlworkspace'
+        name: machineLearning.name
+        resourceId: machineLearning.outputs.workspaceId
+      }
+    ]
   }
+}
 
 output USE_KEY_VAULT string = 'true'
 output AZURE_KEY_VAULT_ENDPOINT string = keyvault.outputs.endpoint
@@ -256,7 +276,7 @@ output OPENAI_API_VERSION string = '2023-03-15-preview'
 output AML_SUBSCRIPTION_ID string = subscription().subscriptionId
 output AML_WORKSPACE_NAME string = machineLearning.outputs.workspaceName
 output AML_RESOURCE_GROUP_NAME string = rgName
-// output AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT string = 
+output AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT string = documentIntelligence.outputs.endpoint
 // output AZURE_DOCUMENT_INTELLIGENCE_ADMIN_KEY string =
 // output AZURE_LANGUAGE_SERVICE_ENDPOINT string =
 // output AZURE_LANGUAGE_SERVICE_KEY string =

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.170.59819",
-      "templateHash": "14273384520214979046"
+      "version": "0.28.1.47646",
+      "templateHash": "10405514002901072370"
     }
   },
   "parameters": {
@@ -130,6 +130,20 @@
         "description": "Azure OpenAI GPT Model Version"
       }
     },
+    "azureAIDocumentIntelligenceResourceName": {
+      "type": "string",
+      "defaultValue": "[format('docintel-{0}', parameters('resourceToken'))]",
+      "metadata": {
+        "description": "Name of Azure AI Document Intelligence Resource"
+      }
+    },
+    "azureAIDocumentIntelligenceSkuName": {
+      "type": "string",
+      "defaultValue": "S0",
+      "metadata": {
+        "description": "Name of Azure AI Document Intelligence SKU"
+      }
+    },
     "applicationInsightsName": {
       "type": "string",
       "defaultValue": "[format('appinsights-{0}', parameters('resourceToken'))]",
@@ -228,8 +242,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.170.59819",
-              "templateHash": "2144895217405179275"
+              "version": "0.28.1.47646",
+              "templateHash": "11344700457585105755"
             }
           },
           "parameters": {
@@ -326,8 +340,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.170.59819",
-              "templateHash": "295197739825834822"
+              "version": "0.28.1.47646",
+              "templateHash": "3835024889022694318"
             },
             "description": "Creates an Azure AI Search instance."
           },
@@ -496,8 +510,153 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.170.59819",
-              "templateHash": "16884678060833239913"
+              "version": "0.28.1.47646",
+              "templateHash": "9219454040579563054"
+            },
+            "description": "Creates an Azure Cognitive Services instance."
+          },
+          "parameters": {
+            "name": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {}
+            },
+            "customSubDomainName": {
+              "type": "string",
+              "defaultValue": "[parameters('name')]",
+              "metadata": {
+                "description": "The custom subdomain name used to access the API. Defaults to the value of the name parameter."
+              }
+            },
+            "deployments": {
+              "type": "array",
+              "defaultValue": []
+            },
+            "kind": {
+              "type": "string",
+              "defaultValue": "OpenAI"
+            },
+            "publicNetworkAccess": {
+              "type": "string",
+              "defaultValue": "Enabled",
+              "allowedValues": [
+                "Enabled",
+                "Disabled"
+              ]
+            },
+            "sku": {
+              "type": "object",
+              "defaultValue": {
+                "name": "S0"
+              }
+            },
+            "allowedIpRules": {
+              "type": "array",
+              "defaultValue": []
+            },
+            "networkAcls": {
+              "type": "object",
+              "defaultValue": "[if(empty(parameters('allowedIpRules')), createObject('defaultAction', 'Allow'), createObject('ipRules', parameters('allowedIpRules'), 'defaultAction', 'Deny'))]"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.CognitiveServices/accounts",
+              "apiVersion": "2023-05-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "kind": "[parameters('kind')]",
+              "properties": {
+                "customSubDomainName": "[parameters('customSubDomainName')]",
+                "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
+                "networkAcls": "[parameters('networkAcls')]"
+              },
+              "sku": "[parameters('sku')]"
+            },
+            {
+              "copy": {
+                "name": "deployment",
+                "count": "[length(parameters('deployments'))]",
+                "mode": "serial",
+                "batchSize": 1
+              },
+              "type": "Microsoft.CognitiveServices/accounts/deployments",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}/{1}', parameters('name'), parameters('deployments')[copyIndex()].name)]",
+              "properties": {
+                "model": "[parameters('deployments')[copyIndex()].model]",
+                "raiPolicyName": "[if(contains(parameters('deployments')[copyIndex()], 'raiPolicyName'), parameters('deployments')[copyIndex()].raiPolicyName, null())]"
+              },
+              "sku": "[if(contains(parameters('deployments')[copyIndex()], 'sku'), parameters('deployments')[copyIndex()].sku, createObject('name', 'Standard', 'capacity', 30))]",
+              "dependsOn": [
+                "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "endpoint": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), '2023-05-01').endpoint]"
+            },
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]"
+            },
+            "name": {
+              "type": "string",
+              "value": "[parameters('name')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('rgName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[parameters('azureAIDocumentIntelligenceResourceName')]",
+      "resourceGroup": "[variables('rgName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[parameters('azureAIDocumentIntelligenceResourceName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[variables('tags')]"
+          },
+          "kind": {
+            "value": "FormRecognizer"
+          },
+          "sku": {
+            "value": {
+              "name": "[parameters('azureAIDocumentIntelligenceSkuName')]"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.28.1.47646",
+              "templateHash": "9219454040579563054"
             },
             "description": "Creates an Azure Cognitive Services instance."
           },
@@ -635,8 +794,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.170.59819",
-              "templateHash": "246951497570111474"
+              "version": "0.28.1.47646",
+              "templateHash": "16657182853649829034"
             },
             "description": "Creates an Azure storage account."
           },
@@ -859,8 +1018,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.170.59819",
-              "templateHash": "17106390582722715244"
+              "version": "0.28.1.47646",
+              "templateHash": "14422276109150612921"
             }
           },
           "parameters": {
@@ -969,8 +1128,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.170.59819",
-              "templateHash": "16886330728560920883"
+              "version": "0.28.1.47646",
+              "templateHash": "16096020836949906486"
             },
             "description": "Creates an Azure Machine Learning Workspace."
           },
@@ -1052,6 +1211,9 @@
           "azureAISearchName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', parameters('azureAISearchName')), '2022-09-01').outputs.name.value]"
           },
+          "documentIntelligenceName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', parameters('azureAIDocumentIntelligenceResourceName')), '2022-09-01').outputs.name.value]"
+          },
           "rgName": {
             "value": "[variables('rgName')]"
           }
@@ -1062,8 +1224,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.170.59819",
-              "templateHash": "10780223516248415530"
+              "version": "0.28.1.47646",
+              "templateHash": "17694120425084503028"
             }
           },
           "parameters": {
@@ -1072,6 +1234,10 @@
               "defaultValue": ""
             },
             "azureOpenAIName": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "documentIntelligenceName": {
               "type": "string",
               "defaultValue": ""
             },
@@ -1087,6 +1253,10 @@
               "type": "string",
               "defaultValue": "openai-api-key"
             },
+            "documentIntelligenceKeyName": {
+              "type": "string",
+              "defaultValue": "azure-document-intelligence-admin-key"
+            },
             "searchKeyName": {
               "type": "string",
               "defaultValue": "azure-search-admin-key"
@@ -1100,6 +1270,15 @@
               "properties": {
                 "contentType": "string",
                 "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('rgName'), 'Microsoft.CognitiveServices/accounts', parameters('azureOpenAIName')), '2023-05-01').key1]"
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('documentIntelligenceKeyName'))]",
+              "properties": {
+                "contentType": "string",
+                "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('rgName'), 'Microsoft.CognitiveServices/accounts', parameters('documentIntelligenceName')), '2023-05-01').key1]"
               }
             },
             {
@@ -1120,11 +1299,16 @@
             "OPENAI_KEY_NAME": {
               "type": "string",
               "value": "[parameters('openAIKeyName')]"
+            },
+            "DOCINTEL_KEY_NAME": {
+              "type": "string",
+              "value": "[parameters('documentIntelligenceKeyName')]"
             }
           }
         }
       },
       "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', parameters('azureAIDocumentIntelligenceResourceName'))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', 'keyvault')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', parameters('azureOpenAIResourceName'))]",
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('rgName'))]",
@@ -1193,8 +1377,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.170.59819",
-              "templateHash": "15313621382123983055"
+              "version": "0.28.1.47646",
+              "templateHash": "284038938591552097"
             }
           },
           "parameters": {
@@ -1337,6 +1521,10 @@
     "AML_RESOURCE_GROUP_NAME": {
       "type": "string",
       "value": "[variables('rgName')]"
+    },
+    "AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('rgName')), 'Microsoft.Resources/deployments', parameters('azureAIDocumentIntelligenceResourceName')), '2022-09-01').outputs.endpoint.value]"
     }
   }
 }

--- a/infra/shared/storekeys.bicep
+++ b/infra/shared/storekeys.bicep
@@ -1,9 +1,11 @@
 param keyVaultName string = ''
 param azureOpenAIName string = ''
+param documentIntelligenceName string = ''
 param azureAISearchName string = ''
 param rgName string = ''
 // Do not use _ in the key names as it is not allowed in the key vault secret name
 param openAIKeyName string = 'openai-api-key'
+param documentIntelligenceKeyName string = 'azure-document-intelligence-admin-key'
 param searchKeyName string = 'azure-search-admin-key'
 
 resource openAIKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
@@ -11,7 +13,27 @@ resource openAIKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
   name: openAIKeyName
   properties: {
     contentType: 'string'
-    value: listKeys(resourceId(subscription().subscriptionId, rgName, 'Microsoft.CognitiveServices/accounts', azureOpenAIName), '2023-05-01').key1
+    value: listKeys(
+      resourceId(subscription().subscriptionId, rgName, 'Microsoft.CognitiveServices/accounts', azureOpenAIName),
+      '2023-05-01'
+    ).key1
+  }
+}
+
+resource documentIntelligenceKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  parent: keyVault
+  name: documentIntelligenceKeyName
+  properties: {
+    contentType: 'string'
+    value: listKeys(
+      resourceId(
+        subscription().subscriptionId,
+        rgName,
+        'Microsoft.CognitiveServices/accounts',
+        documentIntelligenceName
+      ),
+      '2023-05-01'
+    ).key1
   }
 }
 
@@ -20,8 +42,11 @@ resource searchKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
   name: searchKeyName
   properties: {
     contentType: 'string'
-    value: listAdminKeys(resourceId(subscription().subscriptionId, rgName, 'Microsoft.Search/searchServices', azureAISearchName), '2023-11-01').primaryKey
-}
+    value: listAdminKeys(
+      resourceId(subscription().subscriptionId, rgName, 'Microsoft.Search/searchServices', azureAISearchName),
+      '2023-11-01'
+    ).primaryKey
+  }
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
@@ -30,3 +55,4 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
 
 output SEARCH_KEY_NAME string = searchKeySecret.name
 output OPENAI_KEY_NAME string = openAIKeySecret.name
+output DOCINTEL_KEY_NAME string = documentIntelligenceKeySecret.name


### PR DESCRIPTION
This pull request introduces Azure AI Document Intelligence to the infrastructure. The changes includes:

- Adding new parameters, modules, and outputs to support the Azure AI Document Intelligence resource in the `main.bicep` file.
- `storekeys.bicep` has been modified to store the Document Intelligence key in the Azure Key Vault. This is loaded in `environment.py` using the `from_keyvault` method.

Closes #448 