### PR TITLE
Pass `index_config` to load files

### DIFF
--- a/rag_experiment_accelerator/doc_loader/documentLoader.py
+++ b/rag_experiment_accelerator/doc_loader/documentLoader.py
@@ -1,3 +1,4 @@
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.doc_loader.docxLoader import load_docx_files
 from rag_experiment_accelerator.doc_loader.htmlLoader import load_html_files
 from rag_experiment_accelerator.doc_loader.jsonLoader import load_json_files
@@ -49,24 +50,18 @@ def determine_processor(chunking_strategy: ChunkingStrategy, format: str) -> cal
 
 def load_documents(
     environment: Environment,
-    chunking_strategy: ChunkingStrategy,
+    index_config: IndexConfig,
     allowed_formats: list[str],
     file_paths: list[str],
-    chunk_size: int,
-    overlap_size: int,
-    azure_document_intelligence_model: str = None,
 ):
     """
     Load documents from a folder and process them into chunks.
 
     Args:
         environment (Environment): The environment class
-        chunking_strategy (str): The chunking strategy to use between "azure-document-intelligence" and "basic".
+        index_config (IndexConfig): The index configuration class.
         allowed_formats (list[str]]): List of formats, ['*'] - to allow any supported format.
         folder_path (str): Path to the folder containing the documents.
-        chunk_size (int): Size of each chunk.
-        overlap_size (int): Size of overlap between adjacent chunks.
-        azure_document_intelligence_model (str): The model to use for Azure Document Intelligence.
 
     Returns:
         list: A list of dictionaries containing the processed chunks.
@@ -75,6 +70,7 @@ def load_documents(
         FileNotFoundError: When the specified folder does not exist.
     """
 
+    # ['*'] - to allow any supported format.
     if "*" in allowed_formats:
         allowed_formats = _FORMAT_VERSIONS.keys()
 
@@ -93,14 +89,12 @@ def load_documents(
         ]
 
         processor = determine_processor(
-            chunking_strategy=chunking_strategy, format=format
+            chunking_strategy=index_config.chunking.chunking_strategy, format=format
         )
         documents[format] = processor(
             environment=environment,
+            index_config=index_config,
             file_paths=matching_files,
-            chunk_size=chunk_size,
-            overlap_size=overlap_size,
-            azure_document_intelligence_model=azure_document_intelligence_model,
         )
 
     all_documents = []

--- a/rag_experiment_accelerator/doc_loader/docxLoader.py
+++ b/rag_experiment_accelerator/doc_loader/docxLoader.py
@@ -1,5 +1,6 @@
 from langchain_community.document_loaders import Docx2txtLoader
 
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.doc_loader.structuredLoader import (
     load_structured_files,
 )
@@ -11,19 +12,17 @@ logger = get_logger(__name__)
 
 def load_docx_files(
     environment: Environment,
+    index_config: IndexConfig,
     file_paths: list[str],
-    chunk_size: str,
-    overlap_size: str,
     **kwargs: dict,
 ):
     """
     Load and process docx files from a given folder path.
 
     Args:
-        environment (Environment): The environment class
+        environment (Environment): The environment class.
+        index_config (IndexConfig): The index configuration class.
         file_paths (list[str]): Sequence of paths to load.
-        chunk_size (int): The size of each text chunk in characters.
-        overlap_size (int): The size of the overlap between text chunks in characters.
         **kwargs (dict): Unused.
 
 
@@ -38,6 +37,6 @@ def load_docx_files(
         language=None,
         loader=Docx2txtLoader,
         file_paths=file_paths,
-        chunk_size=chunk_size,
-        overlap_size=overlap_size,
+        chunk_size=index_config.chunking.chunk_size,
+        overlap_size=index_config.chunking.overlap_size,
     )

--- a/rag_experiment_accelerator/doc_loader/htmlLoader.py
+++ b/rag_experiment_accelerator/doc_loader/htmlLoader.py
@@ -1,5 +1,6 @@
 from langchain_community.document_loaders import BSHTMLLoader
 
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.doc_loader.structuredLoader import (
     load_structured_files,
 )
@@ -11,9 +12,8 @@ logger = get_logger(__name__)
 
 def load_html_files(
     environment: Environment,
+    index_config: IndexConfig,
     file_paths: list[str],
-    chunk_size: str,
-    overlap_size: str,
     **kwargs: dict,
 ):
     """
@@ -21,10 +21,8 @@ def load_html_files(
 
     Args:
         chunking_strategy (str): The chunking strategy to use between "azure-document-intelligence" and "basic".
+        index_config (IndexConfig): The index configuration class.
         file_paths (list[str]): Sequence of paths to load.
-        chunk_size (str): The size of the chunks to split the documents into.
-        overlap_size (str): The size of the overlapping parts between chunks.
-        glob_patterns (list[str]): List of file extensions to consider (e.g., ["html", "htm", ...]).
         **kwargs (dict): Unused.
 
     Returns:
@@ -38,7 +36,7 @@ def load_html_files(
         language="html",
         loader=BSHTMLLoader,
         file_paths=file_paths,
-        chunk_size=chunk_size,
-        overlap_size=overlap_size,
+        chunk_size=index_config.chunking.chunk_size,
+        overlap_size=index_config.chunking.overlap_size,
         loader_kwargs={"open_encoding": "utf-8"},
     )

--- a/rag_experiment_accelerator/doc_loader/jsonLoader.py
+++ b/rag_experiment_accelerator/doc_loader/jsonLoader.py
@@ -1,3 +1,4 @@
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.doc_loader.customJsonLoader import (
     CustomJSONLoader,
 )
@@ -12,19 +13,17 @@ logger = get_logger(__name__)
 
 def load_json_files(
     environment: Environment,
+    index_config: IndexConfig,
     file_paths: list[str],
-    chunk_size: str,
-    overlap_size: str,
     **kwargs: dict,
 ):
     """
     Load and process Json files from a given folder path.
 
     Args:
-        environment (Environment): The environment class
+        environment (Environment): The environment class.
+        index_config (IndexConfig): The index configuration class.
         file_paths (list[str]): Sequence of paths to load.
-        chunk_size (int): The size of each text chunk in characters.
-        overlap_size (int): The size of the overlap between text chunks in characters.
         **kwargs (dict): Unused.
 
     Returns:
@@ -39,8 +38,8 @@ def load_json_files(
         language=None,
         loader=CustomJSONLoader,
         file_paths=file_paths,
-        chunk_size=chunk_size,
-        overlap_size=overlap_size,
+        chunk_size=index_config.chunking.chunk_size,
+        overlap_size=index_config.chunking.overlap_size,
         loader_kwargs={
             "keys_to_load": keys_to_load,
         },

--- a/rag_experiment_accelerator/doc_loader/markdownLoader.py
+++ b/rag_experiment_accelerator/doc_loader/markdownLoader.py
@@ -1,5 +1,6 @@
 from langchain_community.document_loaders import UnstructuredMarkdownLoader
 
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.doc_loader.structuredLoader import (
     load_structured_files,
 )
@@ -11,19 +12,17 @@ logger = get_logger(__name__)
 
 def load_markdown_files(
     environment: Environment,
+    index_config: IndexConfig,
     file_paths: list[str],
-    chunk_size: str,
-    overlap_size: str,
     **kwargs: dict,
 ):
     """
     Load and process Markdown files from a given folder path.
 
     Args:
-        environment (Environment): The environment class
+        environment (Environment): The environment class.
+        index_config (IndexConfig): The index configuration class.
         file_paths (list[str]): Sequence of paths to load.
-        chunk_size (str): The size of the chunks to split the documents into.
-        overlap_size (str): The size of the overlapping parts between chunks.
         **kwargs (dict): Unused.
 
     Returns:
@@ -37,6 +36,6 @@ def load_markdown_files(
         language="markdown",
         loader=UnstructuredMarkdownLoader,
         file_paths=file_paths,
-        chunk_size=chunk_size,
-        overlap_size=overlap_size,
+        chunk_size=index_config.chunking.chunk_size,
+        overlap_size=index_config.chunking.overlap_size,
     )

--- a/rag_experiment_accelerator/doc_loader/pdfLoader.py
+++ b/rag_experiment_accelerator/doc_loader/pdfLoader.py
@@ -4,6 +4,7 @@ import re
 from langchain_community.document_loaders import PyPDFLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.utils.logging import get_logger
 from rag_experiment_accelerator.config.environment import Environment
 
@@ -39,9 +40,8 @@ def preprocess_pdf_content(content: str):
 
 def load_pdf_files(
     environment: Environment,
+    index_config: IndexConfig,
     file_paths: list[str],
-    chunk_size: int,
-    overlap_size: int,
     **kwargs: dict,
 ):
     """
@@ -49,8 +49,7 @@ def load_pdf_files(
 
     Args:
         environment (Environment): The environment class
-        file_paths (list[str]): Sequence of paths to load.
-        chunk_size (int): The size of each text chunk in characters.
+        index_config (IndexConfig): The index configuration class.
         overlap_size (int): The size of the overlap between text chunks in characters.
         **kwargs (dict): Unused.
 
@@ -66,12 +65,12 @@ def load_pdf_files(
 
     logger.debug(f"Loaded {len(documents)} pages from PDF files")
     text_splitter = RecursiveCharacterTextSplitter(
-        chunk_size=chunk_size,
-        chunk_overlap=overlap_size,
+        chunk_size=index_config.chunking.chunk_size,
+        chunk_overlap=index_config.chunking.overlap_size,
     )
 
     logger.debug(
-        f"Splitting PDF pages into chunks of {chunk_size} characters with an overlap of {overlap_size} characters"
+        f"Splitting PDF pages into chunks of {index_config.chunking.chunk_size} characters with an overlap of {index_config.chunking.overlap_size} characters"
     )
     docs = text_splitter.split_documents(documents)
     docsList = []

--- a/rag_experiment_accelerator/doc_loader/tests/test_custom_html_loader.py
+++ b/rag_experiment_accelerator/doc_loader/tests/test_custom_html_loader.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.doc_loader.htmlLoader import load_html_files
 from rag_experiment_accelerator.config.paths import get_all_file_paths
 
@@ -7,9 +8,10 @@ from rag_experiment_accelerator.config.paths import get_all_file_paths
 def test_load_html_files():
     chunks = load_html_files(
         environment=Mock(),
+        index_config=IndexConfig.from_dict(
+            {"chunking": {"chunk_size": 1000, "overlap_size": 200}}
+        ),
         file_paths=get_all_file_paths("./data/html"),
-        chunk_size=1000,
-        overlap_size=200,
     )
 
     assert len(chunks) == 20

--- a/rag_experiment_accelerator/doc_loader/tests/test_docx_loader.py
+++ b/rag_experiment_accelerator/doc_loader/tests/test_docx_loader.py
@@ -1,19 +1,19 @@
 from unittest.mock import Mock
 
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.doc_loader.docxLoader import load_docx_files
 from rag_experiment_accelerator.config.paths import get_all_file_paths
 
 
 def test_load_docx_files():
     folder_path = "./data/docx"
-    chunk_size = 1000
-    overlap_size = 400
 
     original_doc = load_docx_files(
         environment=Mock(),
+        index_config=IndexConfig.from_dict(
+            {"chunking": {"chunk_size": 1000, "overlap_size": 400}}
+        ),
         file_paths=get_all_file_paths(folder_path),
-        chunk_size=chunk_size,
-        overlap_size=overlap_size,
     )
 
     assert len(original_doc) == 3

--- a/rag_experiment_accelerator/doc_loader/textLoader.py
+++ b/rag_experiment_accelerator/doc_loader/textLoader.py
@@ -1,5 +1,6 @@
 from langchain_community.document_loaders import TextLoader
 
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.doc_loader.structuredLoader import (
     load_structured_files,
 )
@@ -11,20 +12,17 @@ logger = get_logger(__name__)
 
 def load_text_files(
     environment: Environment,
+    index_config: IndexConfig,
     file_paths: list[str],
-    chunk_size: str,
-    overlap_size: str,
     **kwargs: dict,
 ):
     """
     Load and process text files from a given folder path.
 
     Args:
-        environment (Environment): The environment class
-        chunking_strategy (str): The chunking strategy to use between "azure-document-intelligence" and "basic".
+        environment (Environment): The environment class.
+        index_config (IndexConfig): The index configuration class.
         file_paths (list[str]): Sequence of paths to load.
-        chunk_size (int): The size of each text chunk in characters.
-        overlap_size (int): The size of the overlap between text chunks in characters.
         **kwargs (dict): Unused.
 
     Returns:
@@ -38,6 +36,6 @@ def load_text_files(
         language=None,
         loader=TextLoader,
         file_paths=file_paths,
-        chunk_size=chunk_size,
-        overlap_size=overlap_size,
+        chunk_size=index_config.chunking.chunk_size,
+        overlap_size=index_config.chunking.overlap_size,
     )

--- a/rag_experiment_accelerator/run/index.py
+++ b/rag_experiment_accelerator/run/index.py
@@ -57,15 +57,7 @@ def run(
             config.language.analyzer,
         )
 
-    docs = load_documents(
-        environment,
-        index_config.chunking.chunking_strategy,
-        config.data_formats,
-        file_paths,
-        index_config.chunking.chunk_size,
-        index_config.chunking.overlap_size,
-        index_config.chunking.azure_document_intelligence_model,
-    )
+    docs = load_documents(environment, index_config, config.data_formats, file_paths)
 
     if is_local and index_config.sampling.sample_data:
         parser = load_parser()

--- a/rag_experiment_accelerator/run/qa_generation.py
+++ b/rag_experiment_accelerator/run/qa_generation.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 
 from rag_experiment_accelerator.config.config import Config
 from rag_experiment_accelerator.config.environment import Environment
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.data_assets.data_asset import create_data_asset
 from rag_experiment_accelerator.doc_loader.documentLoader import load_documents
 from rag_experiment_accelerator.ingest_data.acs_ingest import generate_qna
@@ -34,6 +35,12 @@ def run(
     logger.info("Running QA generation")
 
     all_docs = {}
+    index_config = IndexConfig.from_dict(
+        {
+            **config.index.to_dict(),
+            **{"chunking": {"chunk_size": 2000, "overlap_size": 0}},
+        }
+    )
     # Check if we have already sampled
     if config.index.sampling.sample_data:
         logger.info("Running QA Generation process with sampling")
@@ -47,11 +54,9 @@ def run(
         else:
             all_docs = load_documents(
                 environment,
-                config.index.chunking.chunking_strategy,
+                index_config,
                 config.data_formats,
                 file_paths,
-                2000,
-                0,
             )
             parser = load_parser()
             all_docs = cluster(
@@ -60,11 +65,9 @@ def run(
     else:
         all_docs = load_documents(
             environment,
-            config.index.chunking.chunking_strategy,
+            index_config,
             config.data_formats,
             file_paths,
-            2000,
-            0,
         )
 
     # generate qna

--- a/rag_experiment_accelerator/run/tests/test_index.py
+++ b/rag_experiment_accelerator/run/tests/test_index.py
@@ -72,6 +72,23 @@ def test_run(
         ],
         sampling=SamplingConfig(sample_data=False),
     )
+    flatten_index_config = IndexConfig(
+        index_name_prefix="prefix",
+        ef_construction=300,
+        ef_search=300,
+        chunking=ChunkingConfig(
+            preprocess=False,
+            chunk_size=10,
+            overlap_size=5,
+            chunking_strategy="chunking_strategy",
+            generate_title=False,
+            generate_summary=False,
+            override_content_with_summary=False,
+            azure_document_intelligence_model="prebuilt-read",
+        ),
+        embedding_model=EmbeddingModelConfig(model_name="model1"),
+        sampling=SamplingConfig(sample_data=False),
+    )
 
     mock_config.language = MagicMock(
         spec=LanguageConfig, analyzer=["analyzer1", "analyzer2"]
@@ -119,8 +136,6 @@ def test_run(
     assert mock_create_acs_index.call_args_list[0][0][0] == "service_endpoint"
     assert mock_create_acs_index.call_args_list[0][0][2] == "admin_key"
 
-    assert mock_load_documents.call_args_list[0][0][1] == "chunking_strategy"
+    assert mock_load_documents.call_args_list[0][0][1] == flatten_index_config
     assert mock_load_documents.call_args_list[0][0][2] == ["format1", "format2"]
     assert mock_load_documents.call_args_list[0][0][3] == file_paths
-    assert mock_load_documents.call_args_list[0][0][4] == 10
-    assert mock_load_documents.call_args_list[0][0][5] == 5

--- a/rag_experiment_accelerator/run/tests/test_qa_generation.py
+++ b/rag_experiment_accelerator/run/tests/test_qa_generation.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from rag_experiment_accelerator.config.index_config import IndexConfig
 from rag_experiment_accelerator.run.qa_generation import run
 
 
@@ -24,11 +25,21 @@ def test_run(
     mock_config = MagicMock()
     mock_config.index.sampling.sample_data = True
     mock_config.index.sampling.optimum_k = 3
+    mock_config.index.to_dict.return_value = {
+        "sampling": {"sample_data": True, "optimum_k": 3},
+    }
 
     sampled_input_data_csv_path = f"{data_dir}/sampling/sampled_cluster_predictions_cluster_number_{mock_config.index.sampling.optimum_k}.csv"
     mock_config.path.sampled_cluster_predictions_path.return_value = (
         sampled_input_data_csv_path
     )
+    index_config = IndexConfig.from_dict(
+        {
+            "sampling": {"sample_data": True, "optimum_k": 3},
+            "chunking": {"chunk_size": 2000, "overlap_size": 0},
+        }
+    )
+
     mock_exists.return_value = False
 
     mock_load_documents.return_value = all_docs_instance = MagicMock()
@@ -42,11 +53,9 @@ def test_run(
     # Assert
     mock_load_documents.assert_called_once_with(
         mock_environment,
-        mock_config.index.chunking.chunking_strategy,
+        index_config,
         mock_config.data_formats,
         filepaths,
-        2000,
-        0,
     )
     mock_generate_qna.assert_called_once_with(
         mock_environment,


### PR DESCRIPTION
To make the `load_<format>_files()` more extensible, instead of passing individual index config settings as a parameter, we pass the `index_config` so that each format file loader can take the required settings.