### PR TITLE
Fixes for index_config

### DIFF
--- a/rag_experiment_accelerator/config/embedding_model_config.py
+++ b/rag_experiment_accelerator/config/embedding_model_config.py
@@ -7,3 +7,4 @@ class EmbeddingModelConfig(BaseConfig):
     type: str = "sentence-transformer"
     model_name: str = "all-mpnet-base-v2"
     dimension: int = None
+    shorten_dimensions: bool = False

--- a/rag_experiment_accelerator/config/index_config.py
+++ b/rag_experiment_accelerator/config/index_config.py
@@ -132,7 +132,7 @@ class IndexConfig(BaseConfig):
         Reverse of index_name().
         """
 
-        key_values = [kv.split("-") for kv in index_name.split("_")]
+        key_values = [kv.split("-", 1) for kv in index_name.split("_")]
         properties = {kv[0]: kv[1].strip() for kv in key_values}
 
         try:

--- a/rag_experiment_accelerator/config/index_config.py
+++ b/rag_experiment_accelerator/config/index_config.py
@@ -93,8 +93,8 @@ class IndexConfig(BaseConfig):
                 chunk_size=int(properties[IndexKey.CHUNK_SIZE]),
                 chunking_strategy=properties[IndexKey.CHUNKING_STRATEGY],
                 overlap_size=int(properties[IndexKey.OVERLAP_SIZE]),
-                generate_title=bool(properties[IndexKey.GENERATE_TITLE]),
-                generate_summary=bool(properties[IndexKey.GENERATE_SUMMARY]),
+                generate_title=bool(int(properties[IndexKey.GENERATE_TITLE])),
+                generate_summary=bool(int(properties[IndexKey.GENERATE_SUMMARY])),
                 override_content_with_summary=bool(
                     properties[IndexKey.OVERRIDE_CONTENT_WITH_SUMMARY]
                 ),

--- a/rag_experiment_accelerator/config/index_config.py
+++ b/rag_experiment_accelerator/config/index_config.py
@@ -89,14 +89,14 @@ class IndexConfig(BaseConfig):
             ef_construction=int(properties[IndexKey.EF_CONSTRUCTION]),
             ef_search=int(properties[IndexKey.EF_SEARCH]),
             chunking=ChunkingConfig(
-                preprocess=bool(properties[IndexKey.PREPROCESS]),
+                preprocess=bool(int(properties[IndexKey.PREPROCESS])),
                 chunk_size=int(properties[IndexKey.CHUNK_SIZE]),
                 chunking_strategy=properties[IndexKey.CHUNKING_STRATEGY],
                 overlap_size=int(properties[IndexKey.OVERLAP_SIZE]),
                 generate_title=bool(int(properties[IndexKey.GENERATE_TITLE])),
                 generate_summary=bool(int(properties[IndexKey.GENERATE_SUMMARY])),
                 override_content_with_summary=bool(
-                    properties[IndexKey.OVERRIDE_CONTENT_WITH_SUMMARY]
+                    int(properties[IndexKey.OVERRIDE_CONTENT_WITH_SUMMARY])
                 ),
             ),
             embedding_model=EmbeddingModelConfig(

--- a/rag_experiment_accelerator/config/tests/data/config.json
+++ b/rag_experiment_accelerator/config/tests/data/config.json
@@ -28,6 +28,17 @@
             {
                 "type": "azure",
                 "model_name": "text-embedding-ada-002"
+            },
+            {
+                "type": "azure",
+                "model_name": "text-embedding-3-large",
+                "dimension": 3072
+            },
+            {
+                "type": "azure",
+                "model_name": "text-embedding-3-small",
+                "dimension": 256,
+                "shorten_dimensions": true
             }
         ],
         "sampling": {

--- a/rag_experiment_accelerator/config/tests/test_config.py
+++ b/rag_experiment_accelerator/config/tests/test_config.py
@@ -32,10 +32,20 @@ def test_config_init(mock_validate_json_with_schema, mock_create_embedding_model
     embedding_model_1 = MagicMock()
     embedding_model_1.model_name.return_value = "all-MiniLM-L6-v2"
     embedding_model_1.dimension.return_value = 384
+    embedding_model_1.shorten_dimensions.return_value = False
     embedding_model_2 = MagicMock()
     embedding_model_2.model_name.return_value = "text-embedding-ada-002"
     embedding_model_2.dimension.return_value = 1536
-    mock_create_embedding_model.side_effect = [embedding_model_1, embedding_model_2]
+    embedding_model_2.shorten_dimensions.return_value = False
+    embedding_model_3 = MagicMock()
+    embedding_model_3.model_name.return_value = "text-embedding-3-large"
+    embedding_model_3.dimension.return_value = 3072
+    embedding_model_3.shorten_dimensions.return_value = False
+    embedding_model_4 = MagicMock()
+    embedding_model_4.model_name.return_value = "text-embedding-3-small"
+    embedding_model_4.dimension.return_value = 256
+    embedding_model_4.shorten_dimensions.return_value = True
+    mock_create_embedding_model.side_effect = [embedding_model_1, embedding_model_2, embedding_model_3, embedding_model_4]
     mock_validate_json_with_schema.return_value = (True, None)
 
     config = Config.from_path(environment, config_path)
@@ -87,6 +97,15 @@ def test_config_init(mock_validate_json_with_schema, mock_create_embedding_model
 
     assert index.embedding_model[1].type == mock_embedding[1]["type"]
     assert index.embedding_model[1].model_name == mock_embedding[1]["model_name"]
+
+    assert index.embedding_model[2].type == mock_embedding[2]["type"]
+    assert index.embedding_model[2].model_name == mock_embedding[2]["model_name"]
+    assert index.embedding_model[2].dimension == mock_embedding[2]["dimension"]
+
+    assert index.embedding_model[3].type == mock_embedding[3]["type"]
+    assert index.embedding_model[3].model_name == mock_embedding[3]["model_name"]
+    assert index.embedding_model[3].dimension == mock_embedding[3]["dimension"]
+    assert index.embedding_model[3].shorten_dimensions == mock_embedding[3]["shorten_dimensions"]
 
     model1 = config.get_embedding_model(config.index.embedding_model[0].model_name)
     assert model1.model_name.return_value == "all-MiniLM-L6-v2"

--- a/rag_experiment_accelerator/config/tests/test_index_config.py
+++ b/rag_experiment_accelerator/config/tests/test_index_config.py
@@ -33,7 +33,7 @@ def test_index_config_to_index_name():
 
 
 def test_index_name_to_index_config():
-    index_name = "idx-prefix_efc-3_efs-4_em-modelname_sp-10_p-0_cs-1_st-abcd_o-2_t-0_s-0_oc-0_d-100"
+    index_name = "idx-prefix_efc-3_efs-4_em-modelname_sp-10_p-0_cs-1_st-abcd_o-2_t-0_s-1_oc-0_d-100"
 
     index_config = IndexConfig.from_index_name(index_name)
 
@@ -41,6 +41,8 @@ def test_index_name_to_index_config():
     assert index_config.chunking.chunk_size == 1
     assert index_config.chunking.chunking_strategy == "abcd"
     assert index_config.chunking.overlap_size == 2
+    assert index_config.chunking.generate_summary is True
+    assert index_config.chunking.generate_title is False
     assert index_config.embedding_model.model_name == "modelname"
     assert index_config.embedding_model.dimension == 100
     assert index_config.ef_construction == 3
@@ -48,7 +50,7 @@ def test_index_name_to_index_config():
 
 
 def test_index_name_to_index_config_shuffled_order():
-    index_name = "idx-prefix_efc-3_efs-4_em-modelname_p-0_cs-1_st-abcd_o-2_t-0_s-0_oc-0_sp-10_d-100"
+    index_name = "idx-prefix_efc-3_efs-4_em-modelname_p-0_cs-1_st-abcd_o-2_t-0_s-1_oc-0_sp-10_d-100"
 
     index_config = IndexConfig.from_index_name(index_name)
 
@@ -56,6 +58,8 @@ def test_index_name_to_index_config_shuffled_order():
     assert index_config.chunking.chunk_size == 1
     assert index_config.chunking.chunking_strategy == "abcd"
     assert index_config.chunking.overlap_size == 2
+    assert index_config.chunking.generate_summary is True
+    assert index_config.chunking.generate_title is False
     assert index_config.embedding_model.model_name == "modelname"
     assert index_config.embedding_model.dimension == 100
     assert index_config.ef_construction == 3

--- a/rag_experiment_accelerator/config/tests/test_index_config.py
+++ b/rag_experiment_accelerator/config/tests/test_index_config.py
@@ -73,3 +73,20 @@ def test_index_name_to_index_config_missing_property():
         assert True
     else:
         assert False, "Expected ValueError to be thrown"
+
+
+def test_index_name_to_index_config_hyphens():
+    index_name = (
+        "idx-prefix_efc-3_efs-4_em-model-name_sp-10_p-0_cs-1_st-ab-cd_o-2_t-0_s-0_oc-0_d-100"
+    )
+
+    index_config = IndexConfig.from_index_name(index_name)
+
+    assert index_config.index_name_prefix == "prefix"
+    assert index_config.chunking.chunk_size == 1
+    assert index_config.chunking.chunking_strategy == "ab-cd"
+    assert index_config.chunking.overlap_size == 2
+    assert index_config.embedding_model.model_name == "model-name"
+    assert index_config.embedding_model.dimension == 100
+    assert index_config.ef_construction == 3
+    assert index_config.ef_search == 4


### PR DESCRIPTION
This PR includes a couple of fixes to the config logic.

- `shorten_dimensions` was dropped by mistake in #502; added it back, together with some unit tests
- In `from_index_name()`, limit the split to one element to cater with property names containing hyphens, for example embeddings model names. (+ unit test)
- Booleans were not properly decoded; added fix + tests.