### PR TITLE
Fix indexing step not working properly when "use_checkpoints" is turned on

### DIFF
--- a/rag_experiment_accelerator/checkpoint/tests/test_local_storage_checkpoint.py
+++ b/rag_experiment_accelerator/checkpoint/tests/test_local_storage_checkpoint.py
@@ -32,7 +32,7 @@ class TestLocalStorageCheckpoint(unittest.TestCase):
     def test_wrapped_method_is_cached(self):
         config = MagicMock()
         config.use_checkpoints = True
-        config.artifacts_dir = self.temp_dir
+        config.path.artifacts_dir = self.temp_dir
         init_checkpoint(config)
         checkpoint = get_checkpoint()
         assert isinstance(checkpoint, LocalStorageCheckpoint)


### PR DESCRIPTION
# Fixes #783 
This PR resolves an issue where methods wrapped with the "checkpoint" decorator do not modify input arguments when the result is cached, leading to unexpected behavior. The solution extracts cacheable logic into separate helper methods, and moves the "checkpoint" decorator to these methods, ensuring that the main methods still run and modify the input arguments as expected.