### PR TITLE
Removed unnecessary else clause

### DIFF
--- a/rag_experiment_accelerator/evaluation/llm_based_metrics.py
+++ b/rag_experiment_accelerator/evaluation/llm_based_metrics.py
@@ -24,8 +24,7 @@ def lower_and_strip(text):
     """
     if text is None:
         return ""
-    else:
-        return text.lower().strip()
+    return text.lower().strip()
 
 
 def llm_answer_relevance(


### PR DESCRIPTION
Wow, this project is super cool! I noticed the lower_and_strip method in llm_based_metrics.py had an unnecessary else clause after a return statement. I've altered it to use an early return to keep the logic flat. Hope this helps!